### PR TITLE
Added Steps for building the apidoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ config.json
 *.csr
 *.sublime-project
 *.sublime-workspace
+
+### Docs ###
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -99,4 +99,4 @@ config.json
 *.sublime-workspace
 
 ### Docs ###
-docs/
+doc/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,34 @@ Copy config.json.sample to config.json and edit to match your information.
 
 `go build core/server.go`
 
+## Docs
+
+Api docs are available at https://openaccounting.io/api/
+
+You may also build and run the docs locally with [apidoc](apidocjs.com) 
+
+#### Requires [yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/)
+
+### Step 1:
+
+Install `apidoc`
+
+```bash
+npm install apidoc -g
+```
+
+### Step 2:
+
+Simply run `apidoc` within the source code root directory, this will automatically generate the documentation and write the output to`./doc` 
+
+```bash
+apidoc
+```
+
+### Step 3:
+
+You may now navigate to the `./docs` directory and run any http server, or simply open `index.html` in your favorite browser!
+
 ## Help
 
 [Join our Slack chatroom](https://join.slack.com/t/openaccounting/shared_invite/enQtNDc3NTAyNjYyOTYzLTc0ZjRjMzlhOTg5MmYwNGQxZGQyM2IzZTExZWE0NDFlODRlNGVhZmZiNDkyZDlhODYwZDcyNTQ5ZWJkMDU3N2M) and talk with us!


### PR DESCRIPTION
This PR adds steps to README.md for developers who may want to build and run the apidoc locally. 
Includes the most basic and easy to get running example, with reference links, as well as a link to the one currently up at https://openaccounting.io/api.

I've also added `doc/` to .gitignore so that when we run `apidoc` in the source directory it doesn't interfere with the repo.